### PR TITLE
game.libretro.bnes: Disable build on Android

### DIFF
--- a/game.libretro.bnes/platforms.txt
+++ b/game.libretro.bnes/platforms.txt
@@ -1,1 +1,1 @@
-all
+!android


### PR DESCRIPTION
Compiling for Android gives the error:

```
make[8]: Entering directory 'arm-linux-androideabi-21-debug/build/bnes/src/bnes'
make[8]: *** jni: No such file or directory.  Stop.
```

bNES is missing a jni directory, so I assume it can't be compiled for Android yet.